### PR TITLE
Adjust loss calculation for CET evening window

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,8 @@ import requests
 import json
 import threading
 import time
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 # --- Flask App Initialization ---
 app = Flask("Identify_biggest_stocklosers")
@@ -61,6 +63,13 @@ def load_common_stocks():
     print(f"--- ✅ Complete: Loaded {len(COMMON_STOCK_TICKERS)} unique common stock tickers. ---\n")
 
 
+def is_cet_between_17_and_20():
+    """Return True when the current time in CET is between 17:00 and 20:00."""
+    cet = ZoneInfo("Europe/Paris")
+    now_cet = datetime.now(timezone.utc).astimezone(cet)
+    return 17 <= now_cet.hour < 20
+
+
 def update_top_losers_cache(min_price=15.0):
     """
     This function runs in a background thread to fetch the latest loser data
@@ -84,6 +93,8 @@ def update_top_losers_cache(min_price=15.0):
         print(f"  [FATAL ERROR] A network error occurred while fetching snapshot: {e}")
         return
 
+    use_prev_close_reference = is_cet_between_17_and_20()
+
     calculated_losers = []
     
     with data_lock:
@@ -96,17 +107,26 @@ def update_top_losers_cache(min_price=15.0):
         if ticker not in local_tickers:
             continue
 
-        previous_close = snap.get("prevDay", {}).get("c")
-
-        if not previous_close or previous_close < min_price:
-            continue
-            
         current_price = snap.get("lastTrade", {}).get("p") or snap.get("day", {}).get("c")
 
         if not current_price:
             continue
-            
-        change_pct = ((current_price - previous_close) / previous_close) * 100
+
+        if current_price < min_price:
+            continue
+
+        previous_close = snap.get("prevDay", {}).get("c")
+        day_open = snap.get("day", {}).get("o")
+
+        if use_prev_close_reference:
+            reference_price = previous_close
+        else:
+            reference_price = day_open if day_open else previous_close
+
+        if not reference_price or reference_price < min_price:
+            continue
+
+        change_pct = ((current_price - reference_price) / reference_price) * 100
 
         if change_pct >= 0:
             continue


### PR DESCRIPTION
## Summary
- add CET-aware helper to detect the 17:00-20:00 window
- switch the loss baseline to the prior trading day's close during that window
- enforce the $15 minimum on both the reference and current prices

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_b_68e537ea80f083299791af26ef0950cd